### PR TITLE
CodeActivityBase thread safety implementation

### DIFF
--- a/JonasPluginBase/JonasCodeActivityBase.cs
+++ b/JonasPluginBase/JonasCodeActivityBase.cs
@@ -6,11 +6,9 @@ namespace Jonas
 {
     public abstract class JonasCodeActivityBase : CodeActivity
     {
-        private CodeActivityContext codeActivityContext;
-
         protected override void Execute(CodeActivityContext context)
         {
-            codeActivityContext = context;
+            CodeActivityContext codeActivityContext = context;
 
             using (var bag = new JonasPluginBag(context))
             {

--- a/JonasPluginBase/JonasCodeActivityBase.cs
+++ b/JonasPluginBase/JonasCodeActivityBase.cs
@@ -8,8 +8,6 @@ namespace Jonas
     {
         protected override void Execute(CodeActivityContext context)
         {
-            CodeActivityContext codeActivityContext = context;
-
             using (var bag = new JonasPluginBag(context))
             {
                 var watch = Stopwatch.StartNew();
@@ -31,7 +29,10 @@ namespace Jonas
         }
 
         public abstract void Execute(JonasPluginBag bag);
-
+    }
+    public partial class JonasPluginBag
+    {
+        CodeActivityContext codeActivityContext { get; set; }
         public T GetCodeActivityParameter<T>(InArgument<T> parameter)
         {
             T result = parameter.Get(codeActivityContext);

--- a/JonasPluginBase/JonasPluginBag.cs
+++ b/JonasPluginBase/JonasPluginBag.cs
@@ -111,6 +111,7 @@ namespace Jonas
             var serviceFactory = executionContext.GetExtension<IOrganizationServiceFactory>();
             var service = serviceFactory.CreateOrganizationService(context.InitiatingUserId);
             Service = new JonasServiceProxy(service, this);
+            codeActivityContext = executionContext;
             Init();
         }
 


### PR DESCRIPTION
With it's previous implementation of CodeActivityContext there was a
chance of breaking thread safety of custom workflows. With this fix this
shouldn't be a problem anymore.
But I have to say, that this fix will break any existing usage of this CodeActivityBase in workflows, because now people will need to reference it trough PluginBag. I know this is not optimal for most people, but it will solve the problem some would have with previous implementation.    
This pull request fixes #11 